### PR TITLE
Fix import error handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,7 +4,7 @@ try:
     import sqlite3
     import sys
 except ModuleNotFoundError as e:
-    st.error(f"Missing module: {e.name}. Please install it using 'pip install {e.name}'.")
+    print(f"Missing module: {e.name}. Please install it using 'pip install {e.name}'.")
     sys.exit(1)
 
 # Title of the app


### PR DESCRIPTION
## Summary
- handle missing modules without relying on Streamlit

## Testing
- `python3 -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68888481df7c8332af00a2fa5f167725